### PR TITLE
feat(ckan): edits to the CKAN deployment

### DIFF
--- a/stable/ckan/conf/ckan/overlay-production.ini
+++ b/stable/ckan/conf/ckan/overlay-production.ini
@@ -1,0 +1,28 @@
+# THIS IS AN OVERLAY OVER THE production.ini file.
+# Don't populate things like connection strings here, as
+# those should be configured by the deployment. This is for things like
+# default_views and locale configuration of the application.
+#
+# =============================================================
+#
+# CKAN - Pylons configuration
+#
+# These are some of the configuration options available for your CKAN
+# instance. Check the documentation in 'doc/configuration.rst' or at the
+# following URL for a description of what they do and the full list of
+# available options:
+#
+# http://docs.ckan.org/en/latest/maintaining/configuration.html
+#
+# The %(here)s variable will be replaced with the parent directory of this file
+#
+
+[app:main]
+ckan.site_title = CKAN-FDI
+ckan.site_logo = /base/images/ckan-logo.png
+ckan.site_description =
+ckan.favicon = /base/images/ckan.ico
+ckan.gravatar_default = identicon
+ckan.preview.direct = png jpg gif
+ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain atom csv tsv rss txt json
+ckan.display_timezone = server

--- a/stable/ckan/conf/ckan/prerun.py
+++ b/stable/ckan/conf/ckan/prerun.py
@@ -1,0 +1,98 @@
+"""
+Copyright (c) 2016 Keitaro AB
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import sys
+import subprocess
+import psycopg2
+from sqlalchemy.engine.url import make_url
+import urllib.request, urllib.error, urllib.parse
+import re
+
+import time
+
+ckan_ini = os.environ.get('CKAN_INI', '/srv/app/production.ini')
+
+RETRY = 5
+
+def check_db_connection(retry=None):
+
+    print('[prerun] Start check_db_connection...')
+
+    if retry is None:
+        retry = RETRY
+    elif retry == 0:
+        print('[prerun] Giving up after 5 tries...')
+        sys.exit(1)
+
+    conn_str = os.environ.get('CKAN_SQLALCHEMY_URL', '')
+    try:
+        db_user = make_url(conn_str).username
+        db_passwd = make_url(conn_str).password
+        db_host = make_url(conn_str).host
+        db_name = make_url(conn_str).database
+        connection = psycopg2.connect(user=db_user,
+                               host=db_host,
+                               password=db_passwd,
+                               database=db_name)
+
+    except psycopg2.Error as e:
+        print((str(e)))
+        print('[prerun] Unable to connect to the database...try again in a while.')
+        import time
+        time.sleep(10)
+        check_db_connection(retry = retry - 1)
+    else:
+        connection.close()
+
+
+def check_solr_connection(retry=None):
+
+    print('[prerun] Start check_solr_connection...')
+
+    if retry is None:
+        retry = RETRY
+    elif retry == 0:
+        print('[prerun] Giving up after 5 tries...')
+        sys.exit(1)
+
+    url = os.environ.get('CKAN_SOLR_URL', '')
+    search_url = '{url}/select/?q=*&wt=json'.format(url=url)
+
+    try:
+        connection = urllib.request.urlopen(search_url)
+    except urllib.error.URLError as e:
+        print('[prerun] Unable to connect to solr...try again in a while.')
+        import time
+        time.sleep(10)
+        check_solr_connection(retry = retry - 1)
+    else:
+        import re
+        conn_info = connection.read()
+        # SolrCloud
+        conn_info = re.sub(r'"zkConnected":true', '"zkConnected":True', conn_info.decode('utf-8'))
+        eval(conn_info)
+
+
+if __name__ == '__main__':
+
+    maintenance = os.environ.get('MAINTENANCE_MODE', '').lower() == 'true'
+
+    if maintenance:
+        print('[prerun] Maintenance mode, skipping setup...')
+    else:
+        check_db_connection()
+        check_solr_connection()

--- a/stable/ckan/templates/cm/ckan-overlay.yaml
+++ b/stable/ckan/templates/cm/ckan-overlay.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ckan-ini-overlay-configmap
+data:
+  production.ini: |
+{{ .Files.Get "conf/ckan/overlay-production.ini" | indent 4 }}

--- a/stable/ckan/templates/cm/ckan-prerun.yaml
+++ b/stable/ckan/templates/cm/ckan-prerun.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ckan-prerun-configmap
+data:
+  prerun.py: |
+{{ .Files.Get "conf/ckan/prerun.py" | indent 4 }}

--- a/stable/ckan/templates/deploy/ckan.yaml
+++ b/stable/ckan/templates/deploy/ckan.yaml
@@ -32,6 +32,9 @@ spec:
         - name: ckan-ini-overlay-configmap
           configMap:
             name: ckan-ini-overlay-configmap
+        - name: ckan-prerun-configmap
+          configMap:
+            name: ckan-prerun-configmap
       {{ if .Values.solr.initialize.enabled }}
         - name: solr-init-configmap
           configMap:
@@ -230,6 +233,7 @@ spec:
             echo "Applying the production.ini overlay..."
             ckan config-tool /srv/app/production.ini -f /config/production.ini
             ckan -c /srv/app/production.ini db init
+            python3 /srv/prerun/prerun.py
             ckan -c /srv/app/production.ini run --host 0.0.0.0
           ports:
             - name: http
@@ -347,6 +351,8 @@ spec:
             failureThreshold: {{ .Values.ckan.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.ckan.liveness.timeoutSeconds }}
           volumeMounts:
+          - name: ckan-prerun-configmap
+            mountPath: /srv/prerun
           - name: ckan-ini-overlay-configmap
             mountPath: /config/
           - name: ckan-config

--- a/stable/ckan/templates/deploy/ckan.yaml
+++ b/stable/ckan/templates/deploy/ckan.yaml
@@ -29,6 +29,9 @@ spec:
       securityContext:
         {{- toYaml .Values.ckan.podSecurityContext | nindent 8 }}
       volumes:
+        - name: ckan-ini-overlay-configmap
+          configMap:
+            name: ckan-ini-overlay-configmap
       {{ if .Values.solr.initialize.enabled }}
         - name: solr-init-configmap
           configMap:
@@ -224,6 +227,8 @@ spec:
                     print(f"{k} = {getenv(v)}")
             EOF
             ckan config-tool /srv/app/production.ini "ckan.plugins = ${CKAN_PLUGINS}"
+            echo "Applying the production.ini overlay..."
+            ckan config-tool /srv/app/production.ini -f /config/production.ini
             ckan -c /srv/app/production.ini db init
             ckan -c /srv/app/production.ini run --host 0.0.0.0
           ports:
@@ -342,6 +347,8 @@ spec:
             failureThreshold: {{ .Values.ckan.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.ckan.liveness.timeoutSeconds }}
           volumeMounts:
+          - name: ckan-ini-overlay-configmap
+            mountPath: /config/
           - name: ckan-config
             mountPath: /srv/app
             readOnly: false

--- a/stable/ckan/templates/deploy/ckan.yaml
+++ b/stable/ckan/templates/deploy/ckan.yaml
@@ -223,6 +223,7 @@ spec:
                 if getenv(v):
                     print(f"{k} = {getenv(v)}")
             EOF
+            ckan config-tool /srv/app/production.ini "ckan.plugins = ${CKAN_PLUGINS}"
             ckan -c /srv/app/production.ini db init
             ckan -c /srv/app/production.ini run --host 0.0.0.0
           ports:

--- a/stable/ckan/values.yaml
+++ b/stable/ckan/values.yaml
@@ -169,6 +169,9 @@ solr:
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/redis/README.md
 redis:
   enabled: true
+  # At the moment CKAN doesn't support Redis with a password, though that
+  # would be an easy patch.
+  usePassword: false
   image:
     registry: docker.io
     repository: bitnami/redis

--- a/stable/ckan/values.yaml
+++ b/stable/ckan/values.yaml
@@ -58,7 +58,7 @@ ckan:
     RoDbUser: datastorero
     RoDbPassword: pass
   solr: "http://solr-headless:8983/solr/ckancollection"
-  redis: "redis://redis-headless:6379/0"
+  redis: "redis://ckan-redis-headless:6379/0"
   spatialBackend: "solr"
   locale:
     offered: "en"

--- a/stable/ckan/values.yaml
+++ b/stable/ckan/values.yaml
@@ -39,7 +39,7 @@ ckan:
   siteTitle: "Site Title here"
   siteId: "site-id-here"
   siteUrl: "http://localhost:5000"
-  ckanPlugins: "envvars image_view text_view recline_view datastore datapusher"
+  ckanPlugins: "image_view text_view recline_view datastore datapusher"
   storagePath: "/var/lib/ckan/default"
   activityStreamsEmailNotifications: "true"
   debug: "false"


### PR DESCRIPTION
Adds a few small fixes:

- Redis now gets connected (had the wrong url and some password issues)
- Fix a CKAN plugins issue
- Add ability to overlay production.ini files from a configmap (only for non-sensitive info like `siteTitle: CKAN-FDI`)
- Add a `prerun.py` script to ensure that solr and postgres are accepting connections before ckan starts (Before ckan could start with a broken solr client, it seemed!).

The redis fixes might have alternative solutions (i.e. using a `nameOverride` or patching CKAN to support authenticated Redis). Feel free to cherry-pick the commits as you prefer them, and the FDI team can fix redis if they're interested.