### PR TITLE
fix(ckan): sastojson chmod delete from helm

### DIFF
--- a/stable/ckan/Chart.yaml
+++ b/stable/ckan/Chart.yaml
@@ -1,7 +1,7 @@
 name: ckan
 apiVersion: v2
 type: application
-version: 0.0.12
+version: 0.0.13
 appVersion: 2.9.2
 description: CKAN Helm Chart for Kubernetes.
 keywords:

--- a/stable/ckan/Chart.yaml
+++ b/stable/ckan/Chart.yaml
@@ -1,7 +1,7 @@
 name: ckan
 apiVersion: v2
 type: application
-version: 0.0.13
+version: 0.0.14
 appVersion: 2.9.2
 description: CKAN Helm Chart for Kubernetes.
 keywords:

--- a/stable/ckan/templates/deploy/ckan.yaml
+++ b/stable/ckan/templates/deploy/ckan.yaml
@@ -90,24 +90,6 @@ spec:
           mountPath: {{ .Values.ckan.storagePath }}
           readOnly: false
       {{ end }}
-      - name: set-volume-ownership-for-sastojson-upload
-        image: busybox
-        command:
-          - "sh"
-          - "-c"
-          - |
-            mkdir -p /srv/app/src/ckanext-sastojson/ckanext/sastojson/upload_files && \
-            mkdir -p /srv/app/src/ckanext-sastojson/ckanext/sastojson/json && \
-            ln -s /lib/ckan/venv/src/ckanext-sastojson/ckanext/sastojson/upload_files /srv/app/src/ckanext-sastojson/ckanext/sastojson/upload_files && \
-            ln -s /lib/ckan/venv/src/ckanext-sastojson/ckanext/sastojson/json /srv/app/src/ckanext-sastojson/ckanext/sastojson/json && \
-            chown -R 900:900 /srv/app/src/ckanext-sastojson/ckanext/sastojson/upload_files && \
-            chown -R 900:900 /srv/app/src/ckanext-sastojson/ckanext/sastojson/json && \
-            chmod 777 -R /srv/app/src/ckanext-sastojson/ckanext/sastojson/upload_files && \
-            chmod 777 -R /srv/app/src/ckanext-sastojson/ckanext/sastojson/json
-        volumeMounts:
-          - name: ckan-config
-            mountPath: /srv/app
-            readOnly: false
       containers:
       {{ if .Values.pgbouncer.enabled }}
         - name: pgbouncer

--- a/stable/ckan/templates/deploy/ckan.yaml
+++ b/stable/ckan/templates/deploy/ckan.yaml
@@ -89,6 +89,7 @@ spec:
         - name: ckan
           mountPath: {{ .Values.ckan.storagePath }}
           readOnly: false
+      {{ end }}
       - name: set-volume-ownership-for-sastojson-upload
         image: busybox
         command:
@@ -107,7 +108,6 @@ spec:
           - name: ckan-config
             mountPath: /srv/app
             readOnly: false
-      {{ end }}
       containers:
       {{ if .Values.pgbouncer.enabled }}
         - name: pgbouncer

--- a/stable/ckan/templates/deploy/ckan.yaml
+++ b/stable/ckan/templates/deploy/ckan.yaml
@@ -369,19 +369,17 @@ spec:
             - name: CKANEXT_ISSUES_SEND_EMAIL_NOTIFICATIONS
               value: {{ .Values.ckan.issues.sendEmailNotifications | quote }}
           readinessProbe:
-            exec:
-              command:
-              - cat
-              - /srv/app
+            httpGet:
+              path: /api/3/action/status_show
+              port: http
             initialDelaySeconds: {{ .Values.ckan.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.ckan.readiness.periodSeconds }}
             failureThreshold: {{ .Values.ckan.readiness.failureThreshold }}
             timeoutSeconds: {{ .Values.ckan.readiness.timeoutSeconds }}
           livenessProbe:
-            exec:
-              command:
-              - cat
-              - /srv/app
+            httpGet:
+              path: /api/3/action/status_show
+              port: http
             initialDelaySeconds: {{ .Values.ckan.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.ckan.liveness.periodSeconds }}
             failureThreshold: {{ .Values.ckan.liveness.failureThreshold }}

--- a/stable/ckan/templates/deploy/ckan.yaml
+++ b/stable/ckan/templates/deploy/ckan.yaml
@@ -369,17 +369,19 @@ spec:
             - name: CKANEXT_ISSUES_SEND_EMAIL_NOTIFICATIONS
               value: {{ .Values.ckan.issues.sendEmailNotifications | quote }}
           readinessProbe:
-            httpGet:
-              path: /api/3/action/status_show
-              port: http
+            exec:
+              command:
+              - cat
+              - /srv/app
             initialDelaySeconds: {{ .Values.ckan.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.ckan.readiness.periodSeconds }}
             failureThreshold: {{ .Values.ckan.readiness.failureThreshold }}
             timeoutSeconds: {{ .Values.ckan.readiness.timeoutSeconds }}
           livenessProbe:
-            httpGet:
-              path: /api/3/action/status_show
-              port: http
+            exec:
+              command:
+              - cat
+              - /srv/app
             initialDelaySeconds: {{ .Values.ckan.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.ckan.liveness.periodSeconds }}
             failureThreshold: {{ .Values.ckan.liveness.failureThreshold }}

--- a/stable/ckan/values.yaml
+++ b/stable/ckan/values.yaml
@@ -91,12 +91,12 @@ ckan:
   extraEnv: []
   readiness:
     initialDelaySeconds: 10
-    periodSeconds: 10
+    periodSeconds: 60
     failureThreshold: 6
     timeoutSeconds: 10
   liveness:
     initialDelaySeconds: 10
-    periodSeconds: 10
+    periodSeconds: 60
     failureThreshold: 6
     timeoutSeconds: 10
   resources: {}


### PR DESCRIPTION
- Removed chmod for sastojson as this now resides (and should always have resided) in the ckan dockerfile
- Changed the liveness/readiness probe frequency
@blairdrummond 