### PR TITLE
fix:(ckan) readiness liveness command instead of httpGet

### DIFF
--- a/stable/ckan/templates/deploy/ckan.yaml
+++ b/stable/ckan/templates/deploy/ckan.yaml
@@ -369,17 +369,19 @@ spec:
             - name: CKANEXT_ISSUES_SEND_EMAIL_NOTIFICATIONS
               value: {{ .Values.ckan.issues.sendEmailNotifications | quote }}
           readinessProbe:
-            httpGet:
-              path: /api/3/action/status_show
-              port: http
+            exec:
+              command:
+              - cat
+              - /srv/app
             initialDelaySeconds: {{ .Values.ckan.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.ckan.readiness.periodSeconds }}
             failureThreshold: {{ .Values.ckan.readiness.failureThreshold }}
             timeoutSeconds: {{ .Values.ckan.readiness.timeoutSeconds }}
           livenessProbe:
-            httpGet:
-              path: /api/3/action/status_show
-              port: http
+            exec:
+              command:
+              - cat
+              - /srv/app
             initialDelaySeconds: {{ .Values.ckan.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.ckan.liveness.periodSeconds }}
             failureThreshold: {{ .Values.ckan.liveness.failureThreshold }}

--- a/stable/ckan/templates/deploy/ckan.yaml
+++ b/stable/ckan/templates/deploy/ckan.yaml
@@ -370,18 +370,14 @@ spec:
               value: {{ .Values.ckan.issues.sendEmailNotifications | quote }}
           readinessProbe:
             exec:
-              command:
-              - cat
-              - /srv/app
+              command: [ "/bin/sh", "-c", "test -d '/srv/app'" ]
             initialDelaySeconds: {{ .Values.ckan.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.ckan.readiness.periodSeconds }}
             failureThreshold: {{ .Values.ckan.readiness.failureThreshold }}
             timeoutSeconds: {{ .Values.ckan.readiness.timeoutSeconds }}
           livenessProbe:
             exec:
-              command:
-              - cat
-              - /srv/app
+              command: ["/bin/sh", "-c", "test -d '/srv/app'"]
             initialDelaySeconds: {{ .Values.ckan.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.ckan.liveness.periodSeconds }}
             failureThreshold: {{ .Values.ckan.liveness.failureThreshold }}


### PR DESCRIPTION
- Added readiness/liveness probe as a command in place of the problematic httpGet call