### PR TITLE
feat(argocd-operator): add argocd-vault-plugin

### DIFF
--- a/stable/argocd-operator/templates/_helpers.tpl
+++ b/stable/argocd-operator/templates/_helpers.tpl
@@ -46,3 +46,13 @@ Selector labels Operator
 app.kubernetes.io/name: {{ include "argocd-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+
+{{/*
+ArgoCD Vault plugin validation
+*/}}
+{{- if .Values.vault.enabled }}
+{{- if ne .Values.vault.auth.type "k8s" }}
+{{- fail "This chart currently only supports k8s auth for the argocd-vault-plugin" }}
+{{- end }}
+{{- end }}

--- a/stable/argocd-operator/templates/projects.yaml
+++ b/stable/argocd-operator/templates/projects.yaml
@@ -16,17 +16,8 @@ metadata:
     {{- with .podLabels }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
-spec:
-  {{- with .spec.oidcConfig }}
-  oidcConfig: |
-    {{ toYaml . | nindent 8 }}
-  {{ end }}
-  {{- with .spec.rbac }}
-  rbac:
-    {{ toYaml . | nindent 8 }}
-  {{ end }}
-  {{- with .spec.server }}
-  server:
-    {{ toYaml . | nindent 8 }}
+spec: {{- with .spec }}
+  # See https://argocd-operator.readthedocs.io/en/latest/reference/api.html/#argoproj.io/v1alpha1.ArgoCDSpec
+  {{ toYaml . | nindent 2 }}
   {{ end }}
 {{ end }}

--- a/stable/argocd-operator/templates/vault-plugin/cluster-role-binding.yaml
+++ b/stable/argocd-operator/templates/vault-plugin/cluster-role-binding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.vault.enabled  }}
+{{ range .Values.projects }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: role-tokenreview-binding-{{ .namespace }}
+  namespace: {{ .namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server-vault
+  namespace: {{ .namespace }}
+{{ end }}
+{{- end }}

--- a/stable/argocd-operator/templates/vault-plugin/plugin-secret.yaml
+++ b/stable/argocd-operator/templates/vault-plugin/plugin-secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.vault.enabled  }}
+{{ range .Values.projects }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: argocd-vault-secret
+  namespace: {{ .namespace }}
+stringData:
+  VAULT_ADDR: {{ $.Values.vault.auth.url }}
+  AVP_AUTH_TYPE: {{ $.Values.vault.auth.type }}
+  AVP_TYPE: vault
+  # The kubernetes role in vault
+  # https://github.com/IBM/argocd-vault-plugin/blob/main/docs/config.md#full-list-of-supported-parameters
+  AVP_K8S_ROLE: {{ $.Values.vault.auth.rolePrefix }}{{ .namespace }}
+{{ end }}
+{{- end }}

--- a/stable/argocd-operator/templates/vault-plugin/plugin-secret.yaml
+++ b/stable/argocd-operator/templates/vault-plugin/plugin-secret.yaml
@@ -13,6 +13,6 @@ stringData:
   AVP_TYPE: vault
   # The kubernetes role in vault
   # https://github.com/IBM/argocd-vault-plugin/blob/main/docs/config.md#full-list-of-supported-parameters
-  AVP_K8S_ROLE: {{ $.Values.vault.auth.rolePrefix }}{{ .namespace }}
+  AVP_K8S_ROLE: {{ $.Values.vault.auth.rolePrefix }}{{ .namespace | replace "-" "_" }}
 {{ end }}
 {{- end }}

--- a/stable/argocd-operator/templates/vault-plugin/role-binding.yaml
+++ b/stable/argocd-operator/templates/vault-plugin/role-binding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.vault.enabled  }}
+{{ range .Values.projects }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-repo-server-vault
+  namespace: {{ .namespace }}
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server-vault
+  namespace: {{ .namespace }}
+roleRef:
+  kind: Role
+  name: secret-reader
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}
+{{- end }}

--- a/stable/argocd-operator/templates/vault-plugin/role.yaml
+++ b/stable/argocd-operator/templates/vault-plugin/role.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.vault.enabled  }}
+{{ range .Values.projects }}
+---
+# This is to get the argocd-vault-secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader
+  namespace: {{ .namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+{{ end }}
+{{- end }}

--- a/stable/argocd-operator/templates/vault-plugin/serviceaccount.yaml
+++ b/stable/argocd-operator/templates/vault-plugin/serviceaccount.yaml
@@ -1,0 +1,13 @@
+# This is created regardless of whether or not
+# Vault is being used (so that nothing fails)
+# if the service account doesn't exist.
+# This is OK, since the serviceaccount doesn't
+# get a RoleBinding unless Vault is enabled.
+{{ range .Values.projects }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-repo-server-vault
+  namespace: {{ .namespace }}
+{{ end }}

--- a/stable/argocd-operator/values.yaml
+++ b/stable/argocd-operator/values.yaml
@@ -31,9 +31,10 @@ vault:
     # https://github.com/IBM/argocd-vault-plugin/blob/main/docs/config.md
     type: k8s
     # You need to create this kubernetes role in vault
-    # The end role is `{prefix}{namespace}`, like `argocd-dscd-system`.
+    # The end role is `{prefix}{namespace}`, like `argocd_dscd_system`.
     # This is to isolate Vault spaces from eachother.
-    rolePrefix: argocd-
+    # NOTE: The namespace will have "-"s replaced with "_"s
+    rolePrefix: argocd_
 
 
 

--- a/stable/argocd-operator/values.yaml
+++ b/stable/argocd-operator/values.yaml
@@ -22,7 +22,6 @@ operator:
       memory: 256Mi
       ephemeral-storage: 500Mi
 
-
 # For the argocd-vault-plugin
 vault:
   enabled: false
@@ -36,24 +35,21 @@ vault:
     # NOTE: The namespace will have "-"s replaced with "_"s
     rolePrefix: argocd_
 
-
-
 pluginConfig: &pluginConfig |
-    # If the argocd-vault-plugin is not enabled,
-    # then obviously these will not work.
-    - name: argocd-vault-plugin
-      generate:
-        command: ["argocd-vault-plugin"]
-        args: ["-s", "argocd-vault-secret", "generate", "./"]
-    - name: argocd-vault-plugin-helm
-      generate:
-        command: ["sh", "-c"]
-        args: ["helm template . > all.yaml && argocd-vault-plugin -s argocd-vault-secret generate all.yaml"]
-    - name: argocd-vault-plugin-kustomize
-      generate:
-        command: ["sh", "-c"]
-        args: ["kustomize build . > all.yaml && argocd-vault-plugin -s argocd-vault-secret generate all.yaml"]
-
+  # If the argocd-vault-plugin is not enabled,
+  # then obviously these will not work.
+  - name: argocd-vault-plugin
+    generate:
+      command: ["argocd-vault-plugin"]
+      args: ["-s", "argocd-vault-secret", "generate", "./"]
+  - name: argocd-vault-plugin-helm
+    generate:
+      command: ["sh", "-c"]
+      args: ["helm template . > all.yaml && argocd-vault-plugin -s argocd-vault-secret generate all.yaml"]
+  - name: argocd-vault-plugin-kustomize
+    generate:
+      command: ["sh", "-c"]
+      args: ["kustomize build . > all.yaml && argocd-vault-plugin -s argocd-vault-secret generate all.yaml"]
 
 # ## ArgoCD Projects Definition
 # projects:

--- a/stable/argocd-operator/values.yaml
+++ b/stable/argocd-operator/values.yaml
@@ -22,6 +22,38 @@ operator:
       memory: 256Mi
       ephemeral-storage: 500Mi
 
+
+# For the argocd-vault-plugin
+vault:
+  enabled: false
+  auth:
+    url: http://vault.default:8200
+    # https://github.com/IBM/argocd-vault-plugin/blob/main/docs/config.md
+    type: k8s
+    # You need to create this kubernetes role in vault
+    # The end role is `{prefix}{namespace}`, like `argocd-dscd-system`.
+    # This is to isolate Vault spaces from eachother.
+    rolePrefix: argocd-
+
+
+
+pluginConfig: &pluginConfig |
+    # If the argocd-vault-plugin is not enabled,
+    # then obviously these will not work.
+    - name: argocd-vault-plugin
+      generate:
+        command: ["argocd-vault-plugin"]
+        args: ["-s", "argocd-vault-secret", "generate", "./"]
+    - name: argocd-vault-plugin-helm
+      generate:
+        command: ["sh", "-c"]
+        args: ["helm template . > all.yaml && argocd-vault-plugin -s argocd-vault-secret generate all.yaml"]
+    - name: argocd-vault-plugin-kustomize
+      generate:
+        command: ["sh", "-c"]
+        args: ["kustomize build . > all.yaml && argocd-vault-plugin -s argocd-vault-secret generate all.yaml"]
+
+
 # ## ArgoCD Projects Definition
 # projects:
 #   # Project name
@@ -49,6 +81,7 @@ operator:
 #           enabled: true
 #         host: ARGOCD_FQDN
 #         insecure: false
+#       configManagementPlugins: *pluginConfig
 
 #   # Project name
 #   - name: argprojo02
@@ -75,3 +108,4 @@ operator:
 #           enabled: true
 #         host: ARGOCD_FQDN
 #         insecure: false
+#       configManagementPlugins: *pluginConfig


### PR DESCRIPTION
**Still a work in progress!**

I think I am very close, and have things semi-working  (`supersecret` in the picture below comes from Vault)

![Screenshot from 2021-08-22 22-38-09](https://user-images.githubusercontent.com/10801138/130384447-04446abf-6d51-4288-b7c8-63633e5c4136.png)

## Outstanding issues

- [x] I am not sure how you guys configured the service-accounts to deploy from the operator to multiple namespaces; that's not working for me out-of-the-box yet
- [x] The Dockerfile currently lives on my personal github, for two reasons.
    1. The ArgoCD spec doesn't support init containers yet, but [they hopefully will soon](https://github.com/argoproj-labs/argocd-operator/issues/172#issuecomment-897849531)
    2. The argocd-vault-plugin doesn't support multiple namespaces atm, but I have [an open PR](https://github.com/IBM/argocd-vault-plugin/pull/184)

The dockerfile I am using at the moment is here

https://github.com/StatCan/argocd-vault-plugin

```Dockerfile
FROM golang:1.16 AS custom-tools

RUN apt-get install wget git \
	&& mkdir -p /custom-tools/

ARG VAULT_PLUGIN_REF=main
RUN git clone https://github.com/statcan/argocd-vault-plugin.git \
    && cd argocd-vault-plugin \
    && git checkout $VAULT_PLUGIN_REF \
    && go build . \
    && mv argocd-vault-plugin /custom-tools/

FROM argoproj/argocd@sha256:8d1d58ef963f615da97e0b2c54dbe243801d5e7198b98393ab36b7a5768f72a4
COPY --from=custom-tools /custom-tools/argocd-vault-plugin /usr/local/bin/argocd-vault-plugin
```

You set that [here](https://github.com/StatCan/charts/blob/55331ce7d4d3b04b142f0473321428db93f399e7/stable/argocd-operator/values.yaml#L65-L66)