### PR TITLE
fix(geoserver): fix volume mount and bump version

### DIFF
--- a/stable/geoserver/Chart.yaml
+++ b/stable/geoserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: A Helm chart for using GeoServer.
 name: geoserver
-version: 0.0.1
+version: 0.0.2
 appVersion: 2.18.2
 home: http://geoserver.org
 sources:

--- a/stable/geoserver/templates/deploy/geoserver.yaml
+++ b/stable/geoserver/templates/deploy/geoserver.yaml
@@ -43,7 +43,7 @@ spec:
             containerPort: 8080
             protocol: TCP
           volumeMounts:
-            - name: {{ include "geoserver.fullname" . }}
+            - name: geoserver
               mountPath: /opt/geoserver/data_dir
             - name: cm-geoserver
               readOnly: true


### PR DESCRIPTION
Make the volume mount consistent with the [volume name](https://github.com/StatCan/charts/blob/39b5ca6c9b85b09c3d54c197d5610a1a839620db/stable/geoserver/templates/deploy/geoserver.yaml#L93).
Make it static, not dynamic

Co-authored-by: name <kent.jacobs@statcan.gc.ca>