### PR TITLE
fix(profiles-controller): fix rbac for profiles controller

### DIFF
--- a/stable/profiles-controller/Chart.yaml
+++ b/stable/profiles-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/profiles-controller/templates/clusterrole.yaml
+++ b/stable/profiles-controller/templates/clusterrole.yaml
@@ -28,6 +28,18 @@ rules:
   - apiGroups:
       - ''
     resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
       - resourcequotas
     verbs:
       - get


### PR DESCRIPTION
I think this will fix some errors in the rbac controller for profiles; I noticed this in the logs

```
I1102 18:17:55.336357       1 rbac.go:112] creating role binding jose-matsuda/ml-pipeline
E1102 18:17:55.534204       1 controller.go:164] error syncing 'stephen-theobald': rolebindings.rbac.authorization.k8s.io "ml-pipeline" is forbidden: user "system:serviceaccount:daaas-system:profiles-controller" (groups=["system:serviceaccounts" "system:serviceaccounts:daaas-system" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["pods"], Verbs:["delete"]}
```