### PR TITLE
fix(solr): bump solr to mitigate log4j vuln

### DIFF
--- a/stable/ckan/Chart.yaml
+++ b/stable/ckan/Chart.yaml
@@ -1,7 +1,7 @@
 name: ckan
 apiVersion: v2
 type: application
-version: 0.0.18
+version: 0.0.19
 appVersion: 2.9.2
 description: CKAN Helm Chart for Kubernetes.
 keywords:
@@ -30,7 +30,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: solr
-    version: 1.5.7
+    version: 1.5.8
     repository: https://statcan.github.io/charts
     condition: solr.enabled
   - name: datapusher

--- a/stable/ckan/values.yaml
+++ b/stable/ckan/values.yaml
@@ -171,7 +171,7 @@ solr:
     storageSize: 5Gi
   image:
     repository: solr
-    tag: 6.6.6
+    tag: 8.11.1
   zookeeper:
     replicaCount: 1
     persistence:

--- a/stable/solr/Chart.yaml
+++ b/stable/solr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "solr"
-version: "1.5.7"
-appVersion: "8.4.0"
+version: "1.5.8"
+appVersion: "8.11.1"
 description: "A helm chart to install Apache Solr"
 keywords:
   - "solr"

--- a/stable/solr/values.yaml
+++ b/stable/solr/values.yaml
@@ -32,7 +32,7 @@ terminationGracePeriodSeconds: 180
 # Solr image settings
 image:
   repository: solr
-  tag: 8.4.0
+  tag: 8.11.1
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Solr 8.11.1 isn't out yet, but it will fix the log4j issue

https://solr.apache.org/security.html#cve-2021-27905-ssrf-vulnerability-with-the-replication-handler