### PR TITLE
feat(gitea): add env vars for azm psql

### DIFF
--- a/stable/profiles-controller/Chart.yaml
+++ b/stable/profiles-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/profiles-controller/templates/deployment-gitea.yaml
+++ b/stable/profiles-controller/templates/deployment-gitea.yaml
@@ -38,6 +38,8 @@ spec:
             - gitea
             - --argocdnamespace 
             - {{ .Values.components.gitea.namespace }}
+          envFrom:
+              {{- toYaml .Values.components.gitea.envFrom | nindent 14 }}
           env:
             {{- range $env := .Values.extraEnv }}
             - name: {{ $env.name }}

--- a/stable/profiles-controller/values.yaml
+++ b/stable/profiles-controller/values.yaml
@@ -98,6 +98,9 @@ components:
   gitea:
     # argocd namespace
     namespace: "argocd"
+    envFrom:
+      - secretRef:
+          name: "gitea-postgres-connection-unclassified"
 
   blobcsi:
     config: |


### PR DESCRIPTION
This provides the gitea controller it's environment variables required to connect to azm psql, and configure per namespace db's.