### PR TITLE
chore: comment out jwt config due to unsupported k8s version

### DIFF
--- a/stable/trino/templates/deployment-coordinator.yaml
+++ b/stable/trino/templates/deployment-coordinator.yaml
@@ -84,25 +84,25 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-        - name: {{ .Chart.Name }}-jwks-client
-          image: nginxinc/nginx-unprivileged:1.20-alpine
-          securityContext:
-            runAsUser: 101
-          resources:
-            limits:
-              memory: "128Mi"
-              cpu: "100m"
-          ports:
-            - containerPort: 8090
-          volumeMounts:
-            - name: nginx-conf
-              mountPath: /etc/nginx/nginx.conf.tmpl
-              subPath: nginx.conf.tmpl
-              readOnly: true
-            - name: nginx-init
-              mountPath: /docker-entrypoint.d/envsubst-conf.sh
-              subPath: envsubst-conf.sh
-              readOnly: true
+        # - name: {{ .Chart.Name }}-jwks-client
+        #   image: nginxinc/nginx-unprivileged:1.20-alpine
+        #   securityContext:
+        #     runAsUser: 101
+        #   resources:
+        #     limits:
+        #       memory: "128Mi"
+        #       cpu: "100m"
+        #   ports:
+        #     - containerPort: 8090
+        #   volumeMounts:
+        #     - name: nginx-conf
+        #       mountPath: /etc/nginx/nginx.conf.tmpl
+        #       subPath: nginx.conf.tmpl
+        #       readOnly: true
+        #     - name: nginx-init
+        #       mountPath: /docker-entrypoint.d/envsubst-conf.sh
+        #       subPath: envsubst-conf.sh
+        #       readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/trino/values.yaml
+++ b/stable/trino/values.yaml
@@ -52,11 +52,11 @@ additionalJVMConfig: {}
 # todo: implement terraform gitlab secret
 additionalConfigProperties:
   - internal-communication.shared-secret=${ENV:TRINO_SHARED_SECRET}
-coordinatorExtraConfig:
-  - http-server.process-forwarded=true
-  - http-server.authentication.type=JWT
-  - http-server.authentication.jwt.key-file=http://localhost:8090/openid/v1/jwks
-  - http-server.authentication.jwt.user-mapping.pattern=^system:serviceaccount:([^:]+):default$
+coordinatorExtraConfig: {}
+  # - http-server.process-forwarded=true
+  # - http-server.authentication.type=JWT
+  # - http-server.authentication.jwt.key-file=http://localhost:8090/openid/v1/jwks
+  # - http-server.authentication.jwt.user-mapping.pattern=^system:serviceaccount:([^:]+):default$
 additionalLogProperties: {}
 
 additionalExchangeManagerProperties: {}


### PR DESCRIPTION
Comment out jwt config for now since dev/prod k8s (on 1.19) version do not support jwks endpoint (1.20+).