### PR TITLE
fix(argocd-operator): rbac.authorization.k8s.io/v1beta1 API Version Deprecation

### DIFF
--- a/stable/argocd-operator/Chart.yaml
+++ b/stable/argocd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for ArgoCD Operator
 name: argocd-operator
-version: 0.2.0
+version: 0.2.1
 appVersion: v0.1.0
 type: application
 keywords:

--- a/stable/argocd-operator/templates/vault-plugin/cluster-role-binding.yaml
+++ b/stable/argocd-operator/templates/vault-plugin/cluster-role-binding.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.vault.enabled  }}
 {{ range .Values.projects }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: role-tokenreview-binding-{{ .namespace }}


### PR DESCRIPTION
Overview:
Upgraded the rbac.autorization.k8s.io/v1beta1 API version to rbac.autorization.k8s.io/v1 within the argocd-operator vault plugin template. 

Justification:
The rbac.authorization.k8s.io/v1beta1 API version of ClusterRole, ClusterRoleBinding, Role, and RoleBinding is no longer served as of version v1.22 of Kubernetes (refer to https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22). As stated by the Kubernetes deprecation guide, there are no notable changes for migrating the API version from v1beta1 to v1. 

Ref:
- Jira CN-997 (Update ClusterRoleBinding API)
- Jira CN-974 (Kubernetes 1.22.X Upgrade)