### PR TITLE
fix(ingress-istio-controller): networking.k8s.io/v1beta1 api deprecated

### DIFF
--- a/stable/ingress-istio-controller/Chart.yaml
+++ b/stable/ingress-istio-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/ingress-istio-controller/templates/ingressclass.yaml
+++ b/stable/ingress-istio-controller/templates/ingressclass.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingressClass.deploy -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass" }}
-apiVersion: networking.k8s.io/v1beta1
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
+apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: {{ include "ingress-istio-controller.fullname" . }}


### PR DESCRIPTION
Overview:
Upgraded the networking.k8s.io/v1beta1 API version to networking.k8s.io/v1 within the ingress template.

Justification:
The networking.k8s.io/v1beta1 API version of IngressClass is no longer served as of v1.22. of Kubernetes (refer to [deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingressclass-v122)). As stated by the Kubernetes deprecation guide, there are no notable changes for migrating the API version from v1beta1 to v1.

Ref:
Jira CN-999 (Update IngressClass API)