### PR TITLE
fix(ingress): networking.k8s.io/v1beta1 API version deprecation

### DIFF
--- a/stable/analytics-platform/Chart.yaml
+++ b/stable/analytics-platform/Chart.yaml
@@ -1,6 +1,6 @@
 name: analytics-platform
 apiVersion: v1
-version: 0.0.13
+version: 0.0.14
 appVersion: 0.0.1
 description: The Portal for the Analytics Platform DAaaS Portal
 keywords:

--- a/stable/analytics-platform/templates/ing/ingress.yaml
+++ b/stable/analytics-platform/templates/ing/ingress.yaml
@@ -32,7 +32,7 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
-            pathType: { $.Values.ingress.pathType }}
+            pathType: {{ $.Values.ingress.pathType }}
             backend:
               service: 
                 name: {{ $fullName }}-portal

--- a/stable/analytics-platform/templates/ing/ingress.yaml
+++ b/stable/analytics-platform/templates/ing/ingress.yaml
@@ -32,6 +32,7 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: { $.Values.ingress.pathType }}
             backend:
               service: 
                 name: {{ $fullName }}-portal

--- a/stable/analytics-platform/templates/ing/ingress.yaml
+++ b/stable/analytics-platform/templates/ing/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "analytics-platform.fullname" . -}}
 {{- $port := .Values.portal.service.port -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,8 +33,10 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}-portal
-              servicePort: {{ $port }}
+              service: 
+                name: {{ $fullName }}-portal
+                port:
+                  number: {{ $port }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/analytics-platform/values.yaml
+++ b/stable/analytics-platform/values.yaml
@@ -19,7 +19,7 @@ ingress:
     kubernetes.io/ingress.class: istio
   hosts:
     - host: chart-example.local
-      paths: 
+      paths:
         - "/"
   pathType: "ImplementationSpecific"
   tls: []

--- a/stable/analytics-platform/values.yaml
+++ b/stable/analytics-platform/values.yaml
@@ -20,7 +20,7 @@ ingress:
   hosts:
     - host: chart-example.local
       paths:
-        - "/"
+        - "/*"
   pathType: "ImplementationSpecific"
   tls: []
   #  - secretName: chart-example-tls

--- a/stable/analytics-platform/values.yaml
+++ b/stable/analytics-platform/values.yaml
@@ -19,8 +19,9 @@ ingress:
     kubernetes.io/ingress.class: istio
   hosts:
     - host: chart-example.local
-      paths:
-        - '/*'
+      paths: 
+        - "/"
+  pathType: "ImplementationSpecific"
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/stable/geoserver/Chart.yaml
+++ b/stable/geoserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: A Helm chart for using GeoServer.
 name: geoserver
-version: 0.0.2
+version: 0.0.3
 appVersion: 2.18.2
 home: http://geoserver.org
 sources:

--- a/stable/geoserver/templates/ing/geoserver.yaml
+++ b/stable/geoserver/templates/ing/geoserver.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "geoserver.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,10 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: 8080
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: 8080
         {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/geoserver/templates/ing/geoserver.yaml
+++ b/stable/geoserver/templates/ing/geoserver.yaml
@@ -31,7 +31,8 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
-            backend:
+            pathType: {{ $.Values.ingress.pathType }}
+            backend: 
               service:
                 name: {{ $fullName }}
                 port: 

--- a/stable/geoserver/values.yaml
+++ b/stable/geoserver/values.yaml
@@ -42,7 +42,7 @@ ingress:
   hosts:
     - host: chart-example.local
       paths: []
-
+  pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/stable/matomo/Chart.yaml
+++ b/stable/matomo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: A Helm chart for using Matomo
 name: matomo
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.0.1
 home: https://matomo.org
 icon: "https://bitnami.com/assets/stacks/matomo/img/matomo-stack-110x117.png"

--- a/stable/matomo/templates/ingress.yaml
+++ b/stable/matomo/templates/ingress.yaml
@@ -32,7 +32,8 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          - backend:
+          - pathType: $.Values.ingress.pathType
+            backend:
               service:
                 name: {{ $fullName }}
                 port:

--- a/stable/matomo/templates/ingress.yaml
+++ b/stable/matomo/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "matomo.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,7 +33,9 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
   {{- end }}
 {{- end }}

--- a/stable/matomo/values.yaml
+++ b/stable/matomo/values.yaml
@@ -22,6 +22,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
   #  - matomo.local
+  pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/stable/mlflow/Chart.yaml
+++ b/stable/mlflow/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 description: |
   [MLFlow](https://mlflow.org/) is an open source platform specialized in tracking ML experiments, and packaging and deploying ML models.
 name: mlflow
-version: 0.1.4
+version: 0.1.5
 appVersion: 1.7.2
 home: https://mlflow.org/
 sources:

--- a/stable/mlflow/templates/ing/ingress.yaml
+++ b/stable/mlflow/templates/ing/ingress.yaml
@@ -31,6 +31,7 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ $.Values.ingress.pathType }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/stable/mlflow/templates/ing/ingress.yaml
+++ b/stable/mlflow/templates/ing/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mlflow.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,10 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: 5000
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 5000
         {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/mlflow/values.yaml
+++ b/stable/mlflow/values.yaml
@@ -77,7 +77,7 @@ ingress:
     - host: chart-example.local
       # ingress.hosts[0].paths -- A list of objects. Each object should contain a `path` key, and may contain a `serviceNameOverride` and a `servicePortOverride` key. If you do not specify any overrides, the Chart will use the ones for the service it creates automatically. We allow overrides to allow advanced behavior like SSL redirection on the AWS ALB Ingress Controller.
       paths:
-        - "/"
+        - "/*"
         #   serviceNameOverride: chart-example
         #   servicePortOverride: 80
   pathType: "ImplementationSpecific"

--- a/stable/mlflow/values.yaml
+++ b/stable/mlflow/values.yaml
@@ -77,9 +77,10 @@ ingress:
     - host: chart-example.local
       # ingress.hosts[0].paths -- A list of objects. Each object should contain a `path` key, and may contain a `serviceNameOverride` and a `servicePortOverride` key. If you do not specify any overrides, the Chart will use the ones for the service it creates automatically. We allow overrides to allow advanced behavior like SSL redirection on the AWS ALB Ingress Controller.
       paths:
-      - "/*"
-      #   serviceNameOverride: chart-example
-      #   servicePortOverride: 80
+        - "/"
+        #   serviceNameOverride: chart-example
+        #   servicePortOverride: 80
+  pathType: "ImplementationSpecific"
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/stable/orchard-cms/Chart.yaml
+++ b/stable/orchard-cms/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for using OrchardCore cms
 name: orchard-cms
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.0.0
 home: https://www.orchardcore.net/
 sources:

--- a/stable/orchard-cms/templates/ingress.yaml
+++ b/stable/orchard-cms/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "orchard-cms.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -34,7 +34,9 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
   {{- end }}
 {{- end }}

--- a/stable/orchard-cms/templates/ingress.yaml
+++ b/stable/orchard-cms/templates/ingress.yaml
@@ -33,7 +33,8 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          - backend:
+          - pathType: .Values.ingress.pathType  
+            backend:
               service:
                 name: {{ $fullName }}
                 port:

--- a/stable/orchard-cms/values.yaml
+++ b/stable/orchard-cms/values.yaml
@@ -36,6 +36,7 @@ ingress:
   annotations: {}
   hosts:
     - orchard-cms.local
+  pathType: ImplementationSpecific
   tls: []
 
 environmentVariables:

--- a/stable/shiny/Chart.yaml
+++ b/stable/shiny/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: A Helm chart for using Shiny.
 name: shiny
-version: 0.1.2
+version: 0.1.3
 appVersion: 3.6.0
 home: https://rstudio.com/products/shiny/shiny-server/
 sources:

--- a/stable/shiny/templates/ing/shiny.yaml
+++ b/stable/shiny/templates/ing/shiny.yaml
@@ -31,6 +31,7 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ $.Values.ingress.pathType }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/stable/shiny/templates/ing/shiny.yaml
+++ b/stable/shiny/templates/ing/shiny.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "shiny.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,10 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: 80
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 80
         {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/shiny/values.yaml
+++ b/stable/shiny/values.yaml
@@ -24,7 +24,7 @@ ingress:
   hosts:
     - host: chart-example.local
       paths: []
-
+  pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
**Overview**:
Upgraded the networking.k8s.io/v1beta1 API version to networking.k8s.io/v1 within the chart's ingress manifests. The following charts were modified with this change:
-  analytics-platform
- geoserver
- matomo
- mlfow
- orchard-cms
- shiny

**Justification**:
The networking.k8s.io/v1beta1 API version is no longer served as of version v1.22 of Kubernetes (refer to https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22). 

**Ref**:
Jira CN-998 (Update Ingress to networking.k8s.io/v1)
Jira CN-974 (Kubernetes 1.22.X Upgrade)