### PR TITLE
fix(istio-ingress-gateway): Remove unused ciphers

### DIFF
--- a/stable/istio-ingress-gateway/Chart.yaml
+++ b/stable/istio-ingress-gateway/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.5.1

--- a/stable/istio-ingress-gateway/values.yaml
+++ b/stable/istio-ingress-gateway/values.yaml
@@ -40,8 +40,6 @@ https:
   httpsRedirect: true
   # Configure allowed cipher suites.
   cipherSuites:
-    - TLS_AES_256_GCM_SHA384
-    - TLS_AES_128_GCM_SHA256
     - ECDHE-RSA-AES256-GCM-SHA384
     - ECDHE-RSA-AES128-GCM-SHA256
   # Configures if HSTS headers should be added to all responses which do not have it.


### PR DESCRIPTION
The ciphers are incorrectly named, and are intended to reference
the TLS1.3 ciphers. We cannot use TLS1.3 at this time since the
cipher list cannot be changed, and the CHACHA ciphers
are not authorized for use.