### PR TITLE
fix(pc chart): increment profiles controller chart and image

### DIFF
--- a/stable/profiles-controller/Chart.yaml
+++ b/stable/profiles-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.14
+version: 0.5.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/profiles-controller/values.yaml
+++ b/stable/profiles-controller/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: k8scc01covidacr.azurecr.io/profiles-controller
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: bbfd5f3db391bb6fb1e2392201ab1c274916558c
+  tag: 35b2ae0326fbadac38068ee353191b046e54aaa1
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Increment chart version and change image sha to latest build. Removes ml-pipelines rolebinding from rbac.

Part of https://github.com/StatCan/daaas/issues/1449