### PR TITLE
Incremented chart fdi-dotstatsuite-dlm and de-dv to 0.3.0

### DIFF
--- a/stable/fdi-dotstatsuite-de-dv/Chart.yaml
+++ b/stable/fdi-dotstatsuite-de-dv/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/fdi-dotstatsuite-dlm/Chart.yaml
+++ b/stable/fdi-dotstatsuite-dlm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/fdi-dotstatsuite/templates/hpa/authz.yaml
+++ b/stable/fdi-dotstatsuite/templates/hpa/authz.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.authz.enabled -}}
 {{- if .Values.authz.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2 
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dotstatsuite.fullname" . }}-authz

--- a/stable/fdi-dotstatsuite/templates/hpa/nsidesign.yaml
+++ b/stable/fdi-dotstatsuite/templates/hpa/nsidesign.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.nsiDesign.enabled -}}
 {{- if .Values.nsiDesign.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dotstatsuite.fullname" . }}-design

--- a/stable/fdi-dotstatsuite/templates/hpa/nsireset.yaml
+++ b/stable/fdi-dotstatsuite/templates/hpa/nsireset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.nsiReset.enabled -}}
 {{- if .Values.nsiReset.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dotstatsuite.fullname" . }}-reset

--- a/stable/fdi-dotstatsuite/templates/hpa/nsistable.yaml
+++ b/stable/fdi-dotstatsuite/templates/hpa/nsistable.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.nsiStable.enabled -}}
 {{- if .Values.nsiStable.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dotstatsuite.fullname" . }}-stable

--- a/stable/fdi-dotstatsuite/templates/hpa/nsistaging.yaml
+++ b/stable/fdi-dotstatsuite/templates/hpa/nsistaging.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.nsiStaging.enabled -}}
 {{- if .Values.nsiStaging.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dotstatsuite.fullname" . }}-staging

--- a/stable/fdi-dotstatsuite/templates/hpa/transfer.yaml
+++ b/stable/fdi-dotstatsuite/templates/hpa/transfer.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.transfer.enabled -}}
 {{- if .Values.transfer.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dotstatsuite.fullname" . }}-transfer

--- a/stable/fdi-eck/templates/cm/fluentd-config.yaml
+++ b/stable/fdi-eck/templates/cm/fluentd-config.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.ci_slug }}-config-map
-  namespace: {{ .Values.namespace }}
   labels:
     app: fluentd
     kubernetes.io/cluster-service: "true"

--- a/stable/fdi-eck/templates/deploy/elastic.yaml
+++ b/stable/fdi-eck/templates/deploy/elastic.yaml
@@ -2,7 +2,6 @@ apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
   name: {{ .Values.ci_slug }}-elastic-search
-  namespace: fdi
 spec:
   http:
     tls:

--- a/stable/fdi-eck/templates/deploy/kibana.yaml
+++ b/stable/fdi-eck/templates/deploy/kibana.yaml
@@ -2,7 +2,6 @@ apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana
 metadata:
   name: {{ .Values.ci_slug }}-kibana
-  namespace: fdi
 spec:
   version: {{ .Values.elastic.version }}
   count: 1

--- a/stable/fdi-eck/templates/in/elastic_ingress.yaml
+++ b/stable/fdi-eck/templates/in/elastic_ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.ci_slug }}-elasticsearch
-  namespace: fdi
 spec:
   ingressClassName: ingress-istio-controller
   rules:

--- a/stable/fdi-eck/templates/in/kibana_ingress.yaml
+++ b/stable/fdi-eck/templates/in/kibana_ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.ci_slug }}-kibana
-  namespace: fdi
 spec:
   ingressClassName: ingress-istio-controller
   rules:

--- a/stable/fdi-eck/values.yaml
+++ b/stable/fdi-eck/values.yaml
@@ -1,5 +1,4 @@
 ci_slug: "fdi-meta"
-nameSpace: "org-fdi-system"
 
 configMap:
   name: "fdi-fluentd-config"


### PR DESCRIPTION
-Removed namespace from charts since it's set at the project level in argo-cd and octopus in fdi-eck
-Incremented chart for dlm and de-dv to 0.3.0
-changed HorizaontalPod autoscaler to newer version. 