### PR TITLE
fix(values): add custom replica count variables

### DIFF
--- a/stable/profiles-controller/templates/deployment-aaw-trino-schema.yaml
+++ b/stable/profiles-controller/templates/deployment-aaw-trino-schema.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.trinoschema }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-aaw-trino.yaml
+++ b/stable/profiles-controller/templates/deployment-aaw-trino.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.trino }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-authpolicies.yaml
+++ b/stable/profiles-controller/templates/deployment-authpolicies.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.default }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-blob-csi.yaml
+++ b/stable/profiles-controller/templates/deployment-blob-csi.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.blobcsi }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-buckets.yaml
+++ b/stable/profiles-controller/templates/deployment-buckets.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.buckets }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-cloud-main.yaml
+++ b/stable/profiles-controller/templates/deployment-cloud-main.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.cloudmain }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-gitea-protected-b.yaml
+++ b/stable/profiles-controller/templates/deployment-gitea-protected-b.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.giteab }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-gitea-unclassified.yaml
+++ b/stable/profiles-controller/templates/deployment-gitea-unclassified.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.gitea }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-limitranges.yaml
+++ b/stable/profiles-controller/templates/deployment-limitranges.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.default }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-network.yaml
+++ b/stable/profiles-controller/templates/deployment-network.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.default}}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-notebook.yaml
+++ b/stable/profiles-controller/templates/deployment-notebook.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.default }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-quotas.yaml
+++ b/stable/profiles-controller/templates/deployment-quotas.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.default }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-rbac.yaml
+++ b/stable/profiles-controller/templates/deployment-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.default }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/templates/deployment-s3proxy.yaml
+++ b/stable/profiles-controller/templates/deployment-s3proxy.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "profiles-controller.labels" . | nindent 4 }}
 spec:
-  replicas: 0
+  replicas: {{ .Values.replicaCount.s3proxy }}
   selector:
     matchLabels:
       {{- include "profiles-controller.selectorLabels" . | nindent 6 }}

--- a/stable/profiles-controller/values.yaml
+++ b/stable/profiles-controller/values.yaml
@@ -2,12 +2,20 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount:
+  default: 1
+  buckets: 1
+  blobcsi: 0
+  cloudmain: 1
+  gitea: 0
+  giteab: 0
+  s3proxy: 0
+  trino: 1
+  trinoschema: 1
 
 extraEnv:
   - name: REQUEUE_TIME
     value: "5"
-
 
 image:
   repository: k8scc01covidacr.azurecr.io/profiles-controller


### PR DESCRIPTION
We have a need to disable some of the profile controller components that we have created, this currently requires us to disable argocd syncing and manage the changes manually... so let's add custom variables so that we have more control over the deployment of our custom services. We can override these values on an environment specific basis in the aaw-argocd-manifests repo.