### PR TITLE
feat(clusterrole): add destinationrules

### DIFF
--- a/stable/profiles-controller/templates/clusterrole.yaml
+++ b/stable/profiles-controller/templates/clusterrole.yaml
@@ -82,6 +82,7 @@ rules:
     resources:
       - serviceentries
       - virtualservices
+      - destinationrules
     verbs:
       - get
       - list


### PR DESCRIPTION
- The cloud main profiles controller needs to be able to create destinationrule resources