### PR TITLE
Feat(ingressgateways) enable access logging

### DIFF
--- a/stable/istio-ingress-gateway/Chart.yaml
+++ b/stable/istio-ingress-gateway/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.5
+version: 2.6.0

--- a/stable/istio-ingress-gateway/Chart.yaml
+++ b/stable/istio-ingress-gateway/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.5
+version: 2.6.5

--- a/stable/istio-ingress-gateway/templates/telemetry.yaml
+++ b/stable/istio-ingress-gateway/templates/telemetry.yaml
@@ -2,14 +2,14 @@
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
-  name: {{ include "istio-ingress-gateway.fullname" . }}-telemetry
+  name: {{ include "istio-ingress-gateway.fullname" . }}-access-logging
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "istio-ingress-gateway.labels" . | nindent 4 }}
-    {{- if .Values.telemetry.accessLogging.labels }}
-    {{- .Values.telemetry.accessLogging.labels | toYaml | nindent 4 }}
-    {{- end }}
 spec:
+  selector:
+    matchLabels:
+      {{- include "istio-ingress-gateway.selectorLabels" . | nindent 6 }}
   accessLogging:
   - providers:
     - name: envoy

--- a/stable/istio-ingress-gateway/templates/telemetry.yaml
+++ b/stable/istio-ingress-gateway/templates/telemetry.yaml
@@ -3,6 +3,7 @@ apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
   name: {{ include "istio-ingress-gateway.fullname" . }}-telemetry
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "istio-ingress-gateway.labels" . | nindent 4 }}
     {{- if .Values.telemetry.accessLogging.labels }}

--- a/stable/istio-ingress-gateway/templates/telemetry.yaml
+++ b/stable/istio-ingress-gateway/templates/telemetry.yaml
@@ -10,7 +10,6 @@ metadata:
     {{- end }}
 spec:
   accessLogging:
-  - disabled: false  
   - providers:
     - name: envoy
 {{- end }}

--- a/stable/istio-ingress-gateway/templates/telemetry.yaml
+++ b/stable/istio-ingress-gateway/templates/telemetry.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.telemetry.accessLogging.enabled }}
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: {{ include "istio-ingress-gateway.fullname" . }}-telemetry
+  labels:
+    {{- include "istio-ingress-gateway.labels" . | nindent 4 }}
+    {{- if .Values.telemetry.accessLogging.labels }}
+    {{- .Values.telemetry.accessLogging.labels | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  accessLogging:
+  - disabled: false  
+  - providers:
+    - name: envoy
+{{- end }}

--- a/stable/istio-ingress-gateway/values.yaml
+++ b/stable/istio-ingress-gateway/values.yaml
@@ -71,3 +71,9 @@ https:
     # Extra labels to add to the ClusterRole
     # Can be used for ClusterRole Aggregation
     labels: {}
+
+# Configures telemetry on the ingress gateway.
+telemetry:
+  accessLogging:
+    enabled: true
+    labels: {}  

--- a/stable/istio-ingress-gateway/values.yaml
+++ b/stable/istio-ingress-gateway/values.yaml
@@ -77,5 +77,3 @@ telemetry:
   # Enable access logging for the entire mesh
   accessLogging:
     enabled: true
-    # Extra labels to add to Telemetry 
-    labels: {}  

--- a/stable/istio-ingress-gateway/values.yaml
+++ b/stable/istio-ingress-gateway/values.yaml
@@ -72,8 +72,10 @@ https:
     # Can be used for ClusterRole Aggregation
     labels: {}
 
-# Configures telemetry on the ingress gateway.
+# Configures Telemetry on the ingress gateway.
 telemetry:
+  # Enable access logging for the entire mesh
   accessLogging:
     enabled: true
+    # Extra labels to add to Telemetry 
     labels: {}  


### PR DESCRIPTION
CN-1784

Will add istio Telemetry AccessLogging 

This will enable access logging on Ingress Gateways by adding istio Telemetry AccessLogging.  This proposed installation will be mesh wide. Generated logs will be available at stdout.


Reference materiel:
Exemple de code : https://istio.io/latest/docs/reference/config/telemetry/
namespace: istio-system : deploy to the entire mesh
Provider -> envoy : ([Istio / Envoy Access Logs](https://istio.io/latest/docs/tasks/observability/logs/access-log/)) Les logs seront envoyés à stdout.

