### PR TITLE
feat(cnpController/image): use a tagged release by default

### DIFF
--- a/stable/cnp-controller/Chart.yaml
+++ b/stable/cnp-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "0.1.0"

--- a/stable/cnp-controller/values.yaml
+++ b/stable/cnp-controller/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: statcan/cnp-controller
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  # tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
We have tagged releases for the cnpController now and as a result the chart should align. This PR implements the current tagged release as the appVersion and configures the chart to use this by default.